### PR TITLE
Add Tailscale daemon to Fly deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
+FROM tailscale/tailscale:v1.98.9 AS tailscale
+
 FROM denoland/deno:2.9.4
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends fontconfig \
+  && apt-get install -y --no-install-recommends fontconfig iptables \
   && rm -rf /var/lib/apt/lists/*
+COPY --from=tailscale /usr/local/bin/tailscale /usr/local/bin/tailscale
+COPY --from=tailscale /usr/local/bin/tailscaled /usr/local/bin/tailscaled
 COPY ./fonts/impact-font /usr/share/fonts/impact-font
 RUN fc-cache -fv
 WORKDIR /app
@@ -13,4 +17,4 @@ COPY . .
 RUN deno task generate:skills
 RUN deno cache --frozen main.ts src/skills/*/mod.ts
 
-CMD ["task", "start"]
+CMD ["/bin/sh", "/app/start.sh"]

--- a/README.md
+++ b/README.md
@@ -320,11 +320,13 @@ Publishing it in your instance should be easy:
 # get credentials
 fly auth login
 
-# set bot token from @BotFather as a secret
+# set the bot token from @BotFather and a Tailscale auth key as secrets
 #
 # secrets in fly are automatically added to
 # the instance as env vars with the same name
-fly secrets set BOT_TOKEN=123123123:32132132131312
+fly secrets set \
+  BOT_TOKEN=123123123:32132132131312 \
+  TAILSCALE_AUTHKEY=tskey-auth-example
 
 # create a volume to hold persistent group data
 # 1gb is more than enough.
@@ -333,5 +335,16 @@ fly vol create mortybot_data -s 1
 # ship it
 fly deploy
 ```
+
+The Tailscale key should be reusable, pre-authorized, and ephemeral so deploys
+can join the tailnet without manual approval and stale Fly nodes are cleaned up.
+The daemon keeps its node state under `/app/data/tailscale` on the existing Fly
+volume, accepts advertised subnet routes and MagicDNS, and blocks unsolicited
+inbound tailnet connections. Configure the tailnet policy for the key's node or
+tag so it can reach the private model endpoint and port.
+
+`TAILSCALE_ENABLED` is set only in `fly.toml`, so running the Docker image
+elsewhere still starts the bot without requiring Tailscale. Override
+`TAILSCALE_HOSTNAME` if this instance needs a different tailnet name.
 
 Refer to https://fly.io docs for more details on other commons operations.

--- a/fly.toml
+++ b/fly.toml
@@ -25,6 +25,8 @@ primary_region = "ams"
   API_PORT="3000"
   NODE_DEBUG="sharp"
   ENVIRONMENT="production"
+  TAILSCALE_ENABLED="true"
+  TAILSCALE_HOSTNAME="mortybot-fly"
 
 [mounts]
   source="mortybot_data"

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -eu
+
+if [ "${TAILSCALE_ENABLED:-false}" != "true" ]; then
+  exec deno task start
+fi
+
+: "${TAILSCALE_AUTHKEY:?TAILSCALE_AUTHKEY must be set when TAILSCALE_ENABLED=true}"
+
+tailscale_state_dir="${TAILSCALE_STATE_DIR:-/app/data/tailscale}"
+tailscale_socket="/var/run/tailscale/tailscaled.sock"
+tailscale_hostname="${TAILSCALE_HOSTNAME:-${FLY_APP_NAME:-mortybot}}"
+
+mkdir -p "$tailscale_state_dir" /var/run/tailscale
+
+tailscaled \
+  --socket="$tailscale_socket" \
+  --statedir="$tailscale_state_dir" &
+
+tailscale --socket="$tailscale_socket" up \
+  --accept-dns=true \
+  --accept-routes=true \
+  --auth-key="$TAILSCALE_AUTHKEY" \
+  --hostname="$tailscale_hostname" \
+  --shields-up=true \
+  --timeout=30s
+
+exec deno task start


### PR DESCRIPTION
## Summary

- bundle pinned Tailscale client and daemon binaries in the bot image
- start and authenticate Tailscale before the bot on Fly, with MagicDNS and advertised subnet routes enabled
- persist Tailscale state on the existing Fly volume and reject unsolicited inbound tailnet connections
- keep Tailscale opt-in outside Fly and document setup

## Why

The Fly-hosted bot needs private network connectivity to local model endpoints without exposing those endpoints to the public internet.

## Deployment prerequisite

Before merging, set `TAILSCALE_AUTHKEY` on the `mortybot` Fly app to a reusable, pre-authorized, ephemeral auth key. Ensure the key's node or tag is allowed by the tailnet policy to reach the private model endpoint and port.

## Validation

- `deno task verify` (52 tests)
- `docker build -t mortybot:tailscale-pr .`
- verified Tailscale 1.98.9 and nftables-backed iptables in the built image
- verified Fly startup fails clearly when Tailscale is enabled without the required auth key
- `fly config validate --config fly.toml`
